### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main, master]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Run tests - Python ${{ matrix.python-version }}


### PR DESCRIPTION
Potential fix for [https://github.com/Abstract-Data/RyanData-Address-Utils/security/code-scanning/1](https://github.com/Abstract-Data/RyanData-Address-Utils/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/tests.yml` at the workflow root (top level), so it applies to all jobs unless overridden. The best minimal fix is:

- `permissions:`
  - `contents: read`

This matches CodeQL’s recommendation and preserves existing functionality for the shown steps (checkout, cache, setup, tests, and Codecov with explicit token).  
Edit region: directly after the `on:` trigger block and before `jobs:`.

No new methods/imports/definitions are needed since this is YAML workflow configuration only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
